### PR TITLE
feat: add gt lt for string and allow to search 'like value' with case…

### DIFF
--- a/src/main/kotlin/com/sipios/springsearch/QueryVisitorImpl.kt
+++ b/src/main/kotlin/com/sipios/springsearch/QueryVisitorImpl.kt
@@ -14,7 +14,7 @@ class QueryVisitorImpl<T>(private val searchSpecAnnotation: SearchSpec) : QueryB
         return when (ctx.logicalOp.text) {
             "AND" -> left.and(right)
             "OR" -> left.or(right)
-            else -> throw IllegalArgumentException("Invalid logical operator ${ctx.logicalOp.text}")
+            else -> left.and(right)
         }
     }
 

--- a/src/main/kotlin/com/sipios/springsearch/QueryVisitorImpl.kt
+++ b/src/main/kotlin/com/sipios/springsearch/QueryVisitorImpl.kt
@@ -89,9 +89,10 @@ class QueryVisitorImpl<T>(private val searchSpecAnnotation: SearchSpec) : QueryB
 
     override fun visitOpCriteria(ctx: QueryParser.OpCriteriaContext): Specification<T> {
         val key = ctx.key().text
-        var value = ctx.value().text
-        if (ctx.value().STRING() != null) {
-            value = clearString(value)
+        val value = if (ctx.value().STRING() != null) {
+            clearString(ctx.value().text)
+        } else {
+            ctx.value().text
         }
         val matchResult = this.valueRegExp.find(value)
         val op = SearchOperation.getSimpleOperation(ctx.op().text) ?: throw IllegalArgumentException("Invalid operation")

--- a/src/main/kotlin/com/sipios/springsearch/strategies/StringStrategy.kt
+++ b/src/main/kotlin/com/sipios/springsearch/strategies/StringStrategy.kt
@@ -15,16 +15,29 @@ data class StringStrategy(var searchSpecAnnotation: SearchSpec) : ParsingStrateg
         ops: SearchOperation?,
         value: Any?
     ): Predicate? {
-        if (!searchSpecAnnotation.caseSensitiveFlag && value !is List<*>) {
-            val lowerCasedValue = (value as String).lowercase(Locale.getDefault())
-            val loweredFieldValue = builder.lower(path[fieldName])
+        if (value !is List<*>) {
+            // if case-sensitive is enabled, we need to keep the value as is
+            val casedValue = if (searchSpecAnnotation.caseSensitiveFlag) {
+                value.toString()
+            } else {
+                value.toString().lowercase(Locale.ROOT)
+            }
+            val casedField = if (searchSpecAnnotation.caseSensitiveFlag) {
+                path[fieldName]
+            } else {
+                builder.lower(path[fieldName])
+            }
             return when (ops) {
-                SearchOperation.STARTS_WITH -> builder.like(loweredFieldValue, "$lowerCasedValue%")
-                SearchOperation.ENDS_WITH -> builder.like(loweredFieldValue, "%$lowerCasedValue")
-                SearchOperation.CONTAINS -> builder.like((loweredFieldValue), "%$lowerCasedValue%")
-                SearchOperation.DOESNT_START_WITH -> builder.notLike(loweredFieldValue, "$lowerCasedValue%")
-                SearchOperation.DOESNT_END_WITH -> builder.notLike(loweredFieldValue, "%$lowerCasedValue")
-                SearchOperation.DOESNT_CONTAIN -> builder.notLike(loweredFieldValue, "%$lowerCasedValue%")
+                SearchOperation.STARTS_WITH -> builder.like(casedField, "$casedValue%")
+                SearchOperation.ENDS_WITH -> builder.like(casedField, "%$casedValue")
+                SearchOperation.CONTAINS -> builder.like((casedField), "%$casedValue%")
+                SearchOperation.DOESNT_START_WITH -> builder.notLike(casedField, "$casedValue%")
+                SearchOperation.DOESNT_END_WITH -> builder.notLike(casedField, "%$casedValue")
+                SearchOperation.DOESNT_CONTAIN -> builder.notLike(casedField, "%$casedValue%")
+                SearchOperation.GREATER_THAN -> builder.greaterThan(casedField, casedValue)
+                SearchOperation.GREATER_THAN_EQUALS -> builder.greaterThanOrEqualTo(casedField, casedValue)
+                SearchOperation.LESS_THAN -> builder.lessThan(path[fieldName], casedValue)
+                SearchOperation.LESS_THAN_EQUALS -> builder.lessThanOrEqualTo(path[fieldName], casedValue)
                 else -> super.buildPredicate(builder, path, fieldName, ops, value)
             }
         }

--- a/src/main/kotlin/com/sipios/springsearch/strategies/StringStrategy.kt
+++ b/src/main/kotlin/com/sipios/springsearch/strategies/StringStrategy.kt
@@ -16,7 +16,7 @@ data class StringStrategy(var searchSpecAnnotation: SearchSpec) : ParsingStrateg
         value: Any?
     ): Predicate? {
         if (value !is List<*>) {
-            // if case-sensitive is enabled, we need to keep the value as is
+            // if case-sensitive is enabled, we don't change the value
             val casedValue = if (searchSpecAnnotation.caseSensitiveFlag) {
                 value.toString()
             } else {

--- a/src/test/kotlin/com/sipios/springsearch/SpringSearchApplicationTest.kt
+++ b/src/test/kotlin/com/sipios/springsearch/SpringSearchApplicationTest.kt
@@ -1441,6 +1441,35 @@ class SpringSearchApplicationTest {
         val setNames = users.map { user -> user.userFirstName }.toSet()
         Assertions.assertEquals(setOf("david"), setNames)
     }
+    @Test
+    fun canGetUsersWithUserFirstNameGt() {
+        userRepository.save(Users(userFirstName = "abel"))
+        userRepository.save(Users(userFirstName = "bob"))
+        userRepository.save(Users(userFirstName = "connor"))
+        userRepository.save(Users(userFirstName = "david"))
+        val specification = SpecificationsBuilder<Users>(
+            SearchSpec::class.constructors.first().call("", false)
+        ).withSearch("userFirstName > barry'").build()
+        val users = userRepository.findAll(specification)
+        Assertions.assertEquals(3, users.size)
+        val setNames = users.map { user -> user.userFirstName }.toSet()
+        Assertions.assertEquals(setOf("connor", "david", "bob"), setNames)
+    }
+
+    @Test
+    fun canGetUsersWithUserFirstNameLt() {
+        userRepository.save(Users(userFirstName = "abel"))
+        userRepository.save(Users(userFirstName = "bob"))
+        userRepository.save(Users(userFirstName = "connor"))
+        userRepository.save(Users(userFirstName = "david"))
+        val specification = SpecificationsBuilder<Users>(
+            SearchSpec::class.constructors.first().call("", false)
+        ).withSearch("userFirstName < barry'").build()
+        val users = userRepository.findAll(specification)
+        Assertions.assertEquals(1, users.size)
+        val setNames = users.map { user -> user.userFirstName }.toSet()
+        Assertions.assertEquals(setOf("abel"), setNames)
+    }
 
     @Test
     fun canGetUsersWithUserFirstNameCaseSensitive() {

--- a/src/test/kotlin/com/sipios/springsearch/SpringSearchApplicationTest.kt
+++ b/src/test/kotlin/com/sipios/springsearch/SpringSearchApplicationTest.kt
@@ -1412,6 +1412,50 @@ class SpringSearchApplicationTest {
         val setNames = users.map { user -> user.userFirstName }.toSet()
         Assertions.assertEquals(setOf("joe", "jean"), setNames)
     }
+
+    @Test
+    fun canGetUsersWithUserFirstNameBetween() {
+        userRepository.save(Users(userFirstName = "abel"))
+        userRepository.save(Users(userFirstName = "bob"))
+        userRepository.save(Users(userFirstName = "connor"))
+        userRepository.save(Users(userFirstName = "david"))
+        val specification = SpecificationsBuilder<Users>(
+            SearchSpec::class.constructors.first().call("", false)
+        ).withSearch("userFirstName BETWEEN 'aaron' AND 'cyrano'").build()
+        val users = userRepository.findAll(specification)
+        Assertions.assertEquals(3, users.size)
+        val setNames = users.map { user -> user.userFirstName }.toSet()
+        Assertions.assertEquals(setOf("abel", "bob", "connor"), setNames)
+    }
+    @Test
+    fun canGetUsersWithUserFirstNameNotBetween() {
+        userRepository.save(Users(userFirstName = "abel"))
+        userRepository.save(Users(userFirstName = "bob"))
+        userRepository.save(Users(userFirstName = "connor"))
+        userRepository.save(Users(userFirstName = "david"))
+        val specification = SpecificationsBuilder<Users>(
+            SearchSpec::class.constructors.first().call("", false)
+        ).withSearch("userFirstName NOT BETWEEN 'aaron' AND 'cyrano'").build()
+        val users = userRepository.findAll(specification)
+        Assertions.assertEquals(1, users.size)
+        val setNames = users.map { user -> user.userFirstName }.toSet()
+        Assertions.assertEquals(setOf("david"), setNames)
+    }
+
+    @Test
+    fun canGetUsersWithUserFirstNameCaseSensitive() {
+        userRepository.save(Users(userFirstName = "abel"))
+        userRepository.save(Users(userFirstName = "Aaron"))
+        userRepository.save(Users(userFirstName = "connor"))
+        userRepository.save(Users(userFirstName = "david"))
+        // create spec with case sensitive flag
+        val specification = SpecificationsBuilder<Users>(
+            SearchSpec::class.constructors.first().call("", true)
+        ).withSearch("userFirstName : A*").build()
+        val users = userRepository.findAll(specification)
+        Assertions.assertEquals(1, users.size)
+        Assertions.assertEquals("Aaron", users[0].userFirstName)
+    }
     // test for a wrong search, should throw an exception during the parse
     @Test
     fun badRequestWithWrongSearch() {


### PR DESCRIPTION
… sensitive

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/sipios/spring-search//blob/main/CONTRIBUTING.md##Commit-messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
GT,  LT and BETWEEN does not work for string values.  
It is not possible to search with * wildcard and casesentitive flag to true
Issue Number: N/A


## What is the new behavior?
User can now search string value using these operators. 
He can also search with * with and case sensitivity enabled

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information